### PR TITLE
Add name field to registration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
     <div id="signUpBox" class="auth-box hide">
       <h2>회원가입</h2>
       <label>소속 이메일<br><input type="email" id="signEmail" placeholder="user@office.kopo.ac.kr"></label>
+      <label>이름<br><input type="text" id="signName"></label>
       <label>비밀번호<br><input type="password" id="signPwd"></label>
       <button id="signBtn">회원가입</button>
       <div class="link">로그인으로 <a href="#" id="showLogin">돌아가기</a></div>

--- a/public/script.js
+++ b/public/script.js
@@ -122,6 +122,7 @@ async function init() {
         method: 'POST',
         body: JSON.stringify({
           email: document.getElementById('signEmail').value.trim(),
+          name: document.getElementById('signName').value.trim(),
           password: document.getElementById('signPwd').value
         })
       });

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ const sequelize = new Sequelize({
 
 // User 모델
 const User = sequelize.define('User', {
+  name:        { type: DataTypes.STRING, allowNull: false },
   email:       { type: DataTypes.STRING, unique: true },
   passwordHash:{ type: DataTypes.STRING },
   verified:    { type: DataTypes.BOOLEAN, defaultValue: false },
@@ -187,9 +188,12 @@ app.get('/api/status', (req, res) => {
 
 // 5) 회원가입
 app.post('/api/signup', async (req, res) => {
-  const { email, password } = req.body;
+  const { email, password, name } = req.body;
   if (!email.toLowerCase().endsWith('@office.kopo.ac.kr')) {
     return res.status(400).json({ error: '허용되지 않은 도메인입니다' });
+  }
+  if (!name) {
+    return res.status(400).json({ error: '이름을 입력해주세요' });
   }
   try {
     let user = await User.findOne({ where: { email } });
@@ -202,6 +206,7 @@ app.post('/api/signup', async (req, res) => {
     } else {
       const hash = await bcrypt.hash(password, 12);
       user = await User.create({
+        name,
         email,
         passwordHash: hash,
         verified: false,

--- a/tests/plans.test.js
+++ b/tests/plans.test.js
@@ -11,6 +11,7 @@ let token;
 beforeAll(async () => {
   await sequelize.sync({ force: true });
   const user = await User.create({
+    name: 'tester',
     email: 'test@office.kopo.ac.kr',
     passwordHash: 'dummy',
     verified: true


### PR DESCRIPTION
## Summary
- collect a name during signup
- store name in the User model
- include the name when creating test users

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fedbc7b68832594b0265672898d50